### PR TITLE
fix: snapshot.md

### DIFF
--- a/docs/guide/snapshot.md
+++ b/docs/guide/snapshot.md
@@ -56,7 +56,7 @@
 GKD 内部暴露了一个服务, 外部应用(某些快捷手势应用)可以启动这个服务, 启动后将抓取当前界面的快照, 它的路径是
 
 ```text
-li.songe.gkd.debug.SnapshotActionService
+li.songe.gkd.service.SnapshotActionService
 ```
 
 通过这个服务, 你可以通过自定义手势来捕获快照, 可在 [gkd-kit/gkd#253](https://github.com/gkd-kit/gkd/issues/253) 了解更多


### PR DESCRIPTION
服务类名是li.songe.gkd.service.SnapshotActionService

shell脚本参考：
```
# 启动GKD服务快照
am start-foreground-service -n li.songe.gkd/.service.SnapshotActionService
```